### PR TITLE
Add category picker

### DIFF
--- a/digital-closet/ContentView.swift
+++ b/digital-closet/ContentView.swift
@@ -146,6 +146,14 @@ struct AddClothingItemView: View {
     @State private var selectedItem: PhotosPickerItem?
     @State private var selectedImageData: Data?
     @State private var category = ""
+    private let categories = [
+        "Shirt",
+        "Pants",
+        "Jacket",
+        "Dress",
+        "Shoes",
+        "Accessory"
+    ]
     @State private var color = ""
     @State private var season = ""
     @State private var showingError = false
@@ -170,7 +178,13 @@ struct AddClothingItemView: View {
                 }
                 
                 Section {
-                    TextField("Category", text: $category)
+                    Picker("Category", selection: $category) {
+                        Text("Select Category").tag("")
+                        ForEach(categories, id: \.self) { option in
+                            Text(option).tag(option)
+                        }
+                    }
+                    .pickerStyle(.menu)
                     TextField("Color", text: $color)
                     TextField("Season", text: $season)
                 }
@@ -213,7 +227,7 @@ struct AddClothingItemView: View {
         }
         
         guard !category.isEmpty else {
-            errorMessage = "Please enter a category"
+            errorMessage = "Please select a category"
             showingError = true
             return
         }


### PR DESCRIPTION
## Summary
- use Picker for choosing an item's category instead of a text field
- validate with 'Please select a category'

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_683c63bc026083228dbf67bd142c0645